### PR TITLE
Max client connections

### DIFF
--- a/rootfs/etc/consul-template/templates/zoo.ctmpl
+++ b/rootfs/etc/consul-template/templates/zoo.ctmpl
@@ -14,6 +14,7 @@ dataLogDir={{ env "ZOO_DATA_LOG_DIR" }}
 tickTime={{ keyOrDefault (printf "%s/tickTime" $base_path) (env "ZOO_TICK_TIME") }}
 initLimit={{ keyOrDefault (printf "%s/initLimit" $base_path) (env "ZOO_INIT_LIMIT") }}
 syncLimit={{ keyOrDefault (printf "%s/syncLimit" $base_path) (env "ZOO_SYNC_LIMIT") }}
+maxClientCnxns={{ keyOrDefault (printf "%s/maxClientCnxns" $base_path) (env "ZOO_MAX_CLIENT_CNXNS") }}
 
 # Advanced Configuration
 # see: http://zookeeper.apache.org/doc/current/zookeeperAdmin.html#sc_advancedConfiguration

--- a/rootfs/etc/cont-init.d/zookeeper
+++ b/rootfs/etc/cont-init.d/zookeeper
@@ -60,6 +60,8 @@ default_config(){
       echo "initLimit=$ZOO_INIT_LIMIT" >> "$CONFIG"
       echo "syncLimit=$ZOO_SYNC_LIMIT" >> "$CONFIG"
 
+      echo "maxClientCnxns=$ZOO_MAX_CLIENT_CNXNS" >> "$CONFIG"
+
       for server in $ZOO_SERVERS; do
           echo "$server" >> "$CONFIG"
       done


### PR DESCRIPTION
Hi guys this is the PR to add the parameter `maxClientCnxns` in the `zoo.cfg` file.

We can pass the parameter using the environment variable `ZOO_MAX_CLIENT_CNXNS` or through Consul key `service/zookeeper/maxClientCnxns`.

Nik